### PR TITLE
Use VC frontend and its config to call VLink.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 all: $(EXE)
 
 $(EXE) : $(OBJ) 
-	$(VLINK) -bamigahunk -x -Bstatic -Cvbcc -nostdlib $(VBCC)/targets/m68k-amigaos/lib/startup.o $(OBJ) -L$(VBCC)/targets/m68k-amigaos/lib -lvc -o $(EXE)
+	$(CC) $(CONFIG) -g -v $(OBJ) -o $(EXE)
 
 $(ODIR)/%.o : %.c
 	$(CC) $(CONFIG) -g -c -o $@ $<


### PR DESCRIPTION
Hello,

This should fix issue #7 
VC frontend automatically add -mrel parameter when calling VLink in aos68k* and kick13* configs.
We can speak about it on _Amiga France_ ;)